### PR TITLE
Bump Rspec version from 3.0 to 3.1

### DIFF
--- a/truework.gemspec
+++ b/truework.gemspec
@@ -25,8 +25,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'dry-struct', '~> 1.2'
 
   spec.add_development_dependency 'bundler', '~> 2.1'
-  spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'rake', '~> 13.0'
+  spec.add_development_dependency 'rspec', '~> 3.1'
   spec.add_development_dependency 'rubocop', '~> 0.79'
   spec.add_development_dependency 'webmock', '~> 3.8'
 end


### PR DESCRIPTION
When starting out on #5, running  `bundle exec rake spec` I ran into an error

    undefined method `include_chain_clauses_in_custom_matcher_descriptions=' for #<RSpec::Expectations::Configuration:0x00007fde1420e5a0> (NoMethodError)

That is because in `spec/spec_helper.rb` we use

    include_chain_clauses_in_custom_matcher_descriptions = true

which is introduced in rspec 3.1, but our local requirement ties Rspec to 3.0

After updating this rspec and rake, tests work fine locally.