### PR TITLE
Changes to report, salary and employee models

### DIFF
--- a/lib/truework/resources/employee.rb
+++ b/lib/truework/resources/employee.rb
@@ -10,7 +10,7 @@ module Truework
     attribute :last_name, Types::String
     attribute :status, Types::String
     attribute? :hired_date, Types::JSON::Date
-    attribute? :end_of_employment, Types::JSON::Date
+    attribute? :termination_date, Types::JSON::Date
     attribute :social_security_number, Types::String
     attribute? :earnings, Types::Array.of(Earnings)
     attribute? :positions, Types::Array.of(Position)

--- a/lib/truework/resources/report.rb
+++ b/lib/truework/resources/report.rb
@@ -2,6 +2,7 @@
 
 require 'truework/resources/employee'
 require 'truework/resources/employer'
+require 'truework/resources/respondent'
 require 'truework/resources/verification_request'
 
 module Truework
@@ -13,6 +14,8 @@ module Truework
     attribute :verification_request, VerificationRequest
     attribute :employer, Employer
     attribute :employee, Employee
+    attribute? :additional_notes, Types::String
+    attribute? :respondent, Respondent
 
     def self.instance_url(verification_request_id)
       "/verification-requests/#{verification_request_id}/report/"

--- a/lib/truework/resources/respondent.rb
+++ b/lib/truework/resources/respondent.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Truework
+  class Respondent < APIResource
+    attribute? :full_name, Types::String
+    attribute? :title, Types::String
+  end
+end

--- a/lib/truework/resources/salary.rb
+++ b/lib/truework/resources/salary.rb
@@ -5,5 +5,6 @@ module Truework
     attribute :gross_pay, Types::JSON::Decimal
     attribute? :pay_frequency, Types::String
     attribute? :hours_per_week, Types::Coercible::Integer
+    attribute? :reduced_covid, Types::String
   end
 end

--- a/lib/truework/version.rb
+++ b/lib/truework/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Truework
-  VERSION = '1.1.0'
+  VERSION = '2.0.0'
 end

--- a/spec/fixtures/report/report_1.json
+++ b/spec/fixtures/report/report_1.json
@@ -22,7 +22,7 @@
     "last_name": "Last",
     "status": "inactive",
     "hired_date": "2017-08-08",
-    "end_of_employment": "2019-08-08",
+    "termination_date": "2019-08-08",
     "social_security_number": "***-**-9999",
     "earnings": [
       {
@@ -64,7 +64,13 @@
     "salary": {
       "gross_pay": "30000.00",
       "pay_frequency": "annually",
-      "hours_per_week": "40"
-    }
+      "hours_per_week": "40",
+      "reduced_covid": "no"
+    },
+    "respondent": {
+      "title": "some title",
+      "full_name": "first last"
+    },
+    "additional_notes": "some free form text"
   }
 }

--- a/spec/resources/report_spec.rb
+++ b/spec/resources/report_spec.rb
@@ -109,7 +109,7 @@ describe Truework::Report do
           expect(subject.last_name).to eq('Last')
           expect(subject.status).to eq('inactive')
           expect(subject.hired_date).to eq(Date.new(2017, 8, 8))
-          expect(subject.end_of_employment).to eq(Date.new(2019, 8, 8))
+          expect(subject.termination_date).to eq(Date.new(2019, 8, 8))
         end
 
         context 'nested attributes' do
@@ -203,7 +203,7 @@ describe Truework::Report do
               last_name: 'Last',
               status: 'inactive',
               hired_date: Date.new(2017, 8, 8),
-              end_of_employment: Date.new(2019, 8, 8),
+              termination_date: Date.new(2019, 8, 8),
               social_security_number: '***-**-9999',
               earnings: [
                 Truework::Earnings.new(
@@ -245,8 +245,14 @@ describe Truework::Report do
               salary: Truework::Salary.new(
                 gross_pay: '30000.00',
                 pay_frequency: 'annually',
-                hours_per_week: 40
-              )
+                hours_per_week: 40,
+                reduced_covid: 'no'
+              ),
+              respondent: Truework::Respondent.new(
+                full_name: 'first last',
+                title: 'some title'
+              ),
+              additional_notes: 'some free form text'
             )
           )
           expect(subject).to eq(expected)


### PR DESCRIPTION
- Backwards compatible changes:
  - Adding additional_notes and respondent to report model
  - Adding reduced_covid to Salary model

- Backwards incompatible changes:
  - Rename end_of_employment to termination_date in Employee model